### PR TITLE
deploy_to_ec2 jobs 분리

### DIFF
--- a/.github/workflows/deploy_to_ec2.yaml
+++ b/.github/workflows/deploy_to_ec2.yaml
@@ -34,8 +34,28 @@ jobs:
       - name: Build with gradle
         run: ./gradlew build
 
-      - if: ${{ github.repository_owner == 'WhaleAjang' }}
-        name: Copy and Paste jar file to EC2
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_artifact
+          path: build/libs/app.jar
+          retention-days: 7
+          overwrite: true
+
+  deploy:
+    if: ${{ github.repository_owner == 'WhaleAjang' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build_artifact
+          path: build/libs/app.jar
+
+      - name: Copy and Paste jar file to EC2
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.HOST }}
@@ -44,8 +64,7 @@ jobs:
           source: "build/libs/app.jar, Dockerfile, docker-compose.yaml, run.sh, nginx"
           target: /home/${{ secrets.USERNAME }}/
 
-      - if: ${{ github.repository_owner == 'WhaleAjang' }}
-        name: Deploy via run script
+      - name: Deploy via run script
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.HOST }}


### PR DESCRIPTION
## ❓ Why are you writing PR?

- deploy_to_ec2에서 jobs를 분리했습니다.

<br>

## 📝 What's in your PR?

### 🌠 Screenshot (if needs)

> 아래의 GitHub Action은 kiryanchi/PKH 레포지토리에서 진행됐습니다.

**기존**
<img width="284" alt="image" src="https://github.com/WhaleAjang/PKH/assets/50714602/532dcaaa-683e-4ab6-a364-29dde3eb7193">

**변경 후**
<img width="315" alt="image" src="https://github.com/WhaleAjang/PKH/assets/50714602/f87fb1ce-2e53-46e4-ab65-1fb742e17096">

### 📌 Changes

- 빌드와 배포의 jobs를 다르게 설정하여 배포(deploy)는 `repository_owner == WhaleAjang` 일 때만 동작합니다.
  (배포는 무조건 `WhaleAjang`에서만 진행되므로 이후 수정할 가능성이 낮다고 판단해 중복을 제거하였습니다.)

<br>

## ✅ What things reviewers have to check?

- PR이 머지된 후, deploy_to_ec2 action 동작할 때, 배포(deploy)가 동작하는지 확인

<br>

## 🖇️ Relate to

### 🧑‍💻 Reviewers

@kiryanchi

### 👾 Issue

close #